### PR TITLE
(implements #10) support ignoring null attributes.

### DIFF
--- a/jstoxml.js
+++ b/jstoxml.js
@@ -44,7 +44,7 @@ var toXML = function(obj, config){
     
     // turn the attributes object into a string with key="value" pairs
     for(var attr in attrs){
-      if(attrs.hasOwnProperty(attr)) {
+      if(attrs.hasOwnProperty(attr) && (!config.ignoreNullAttrs || attrs[attr])) {
         attrsString += ' ' + attr + '="' + attrs[attr] + '"';
       }
     }

--- a/test.js
+++ b/test.js
@@ -558,7 +558,58 @@ var jstoxml = require('./jstoxml.js');
       });
     },
     expectedOutput: '<foo>&amp;</foo>'
-  });   
+  });
+
+  addTest({
+    name: 'serializationOfNullAttributesWhenNoConfig',
+    input: function(){
+      return jstoxml.toXML({
+        _name: 'foo',
+        _attrs: {
+          attr1: 'v1',
+          attr2: null
+        },
+        _content: 'bar'
+      });
+    },
+    expectedOutput: '<foo attr1="v1" attr2="null">bar</foo>'
+  });
+
+  addTest({
+    name: 'noSerializationOfNullAttributesWhenConfigIsTrue',
+    input: function(){
+      return jstoxml.toXML({
+        _name: 'foo',
+        _attrs: {
+          attr1: 'v1',
+          attr2: null
+        },
+        _content: 'bar'
+      },
+      {
+        ignoreNullAttrs: true
+      });
+    },
+    expectedOutput: '<foo attr1="v1">bar</foo>'
+  });
+
+  addTest({
+    name: 'serializationOfNullAttributesWhenConfigIsFalse',
+    input: function(){
+      return jstoxml.toXML({
+        _name: 'foo',
+        _attrs: {
+          attr1: 'v1',
+          attr2: null
+        },
+        _content: 'bar'
+      },
+      {
+        ignoreNullAttrs: false
+      });
+    },
+    expectedOutput: '<foo attr1="v1" attr2="null">bar</foo>'
+  });
   
   runTests();
   showReport();


### PR DESCRIPTION
Hi, another pull request from Linagora! This time we added support for another configuration setting 'ignoreNullAttrs' that allows a caller to not serialize attributes that are null.
