### PR TITLE
Sibling self closing + nested elements

### DIFF
--- a/jstoxml.js
+++ b/jstoxml.js
@@ -55,7 +55,7 @@ var toXML = function(obj, config){
         attrsString += ' ' + attr + '="' + attrs[attr] + '"';
       }
     }
-    
+
     // assemble the tag
     outputString += (tag.indent || '') + '<' + (tag.closeTag ? '/' : '') + tag.name + (!tag.closeTag ? attrsString : '') + (tag.selfCloseTag ? '/' : '') + '>';
     
@@ -146,7 +146,10 @@ var toXML = function(obj, config){
         
         var type = typeof input._content;
 
-        if(type === 'undefined'){
+        if(type === 'undefined' || input._content._selfCloseTag === true){
+          if (input._content && input._content._attrs) {
+            outputTagObj.attrs = input._content._attrs;
+          }
           outputTagObj.selfCloseTag = true;
           outputTag(outputTagObj);
           return;

--- a/test.js
+++ b/test.js
@@ -598,6 +598,39 @@ var jstoxml = require('./jstoxml.js');
     },
     expectedOutput: '<Hooray For Captain Spaulding, the African Explorer>\n<foo>4</foo>'
   });
+
+  addTest({
+    name: 'nested-elements-with-self-closing-sibling',
+    input: function(){
+      return jstoxml.toXML({
+        people: {
+          students: [
+            {
+              student: { name: 'Joe' }
+            },
+            {
+              student: { name: 'Jane' }
+            }
+          ],
+          teacher: {
+            _selfCloseTag: true,
+            _attrs: {
+              'name': 'Yoda'
+            }
+          }
+        }
+      });
+    },
+    expectedOutput: [
+      '<people>',
+      '<students>',
+      '<student><name>Joe</name></student>',
+      '<student><name>Jane</name></student>',
+      '</students>',
+      '<teacher name="Yoda"/>',
+      '</people>'
+    ].join('')
+  });
   
   runTests();
   showReport();


### PR DESCRIPTION
This patch enables having sibling nodes where one node is a self closing tag with attributes, and another node is an element with children.

For example:

```javascript
return jstoxml.toXML({
  people: {
    students: [
      {
        student: { name: 'Joe' }
      },
      {
        student: { name: 'Jane' }
      }
    ],
    teacher: {
      _selfCloseTag: true,
      _attrs: {
        'name': 'Yoda'
      }
    }
  }
});
```

should return the string (formatted for clarity):

```xml
<people>
  <students>
    <student>
      <name>Joe</name>
    </student>
    <student>
      <name>Jane</name>
    </student>
  </students>
  <teacher name="Yoda"/>
</people>
```