### PR TITLE
Filter attributes

### DIFF
--- a/jstoxml.js
+++ b/jstoxml.js
@@ -52,7 +52,7 @@ var toXML = function(obj, config){
     // turn the attributes object into a string with key="value" pairs
     for(var attr in attrs){
       if(attrs.hasOwnProperty(attr)) {
-        attrsString += ' ' + attr + '="' + attrs[attr] + '"';
+        attrsString += ' ' + attr + '="' + filter(attrs[attr]) + '"';
       }
     }
 


### PR DESCRIPTION
Hi,
Upnp LastChange event model widely use "val" attribute to send complex data, including embed xml witch should be escaped.
Enabling filter on attributes allow those kind of complex attribute without manually unescape.

Is there is another way to do this ?
