### PR TITLE
Handling function outputs as their own types

### DIFF
--- a/jstoxml.js
+++ b/jstoxml.js
@@ -181,7 +181,12 @@ var toXML = function(obj, config){
           },
           
           'function': function(){
-            outputTagObj.text = input._content();  // () to execute the fn
+            outputTag(outputTagObj);
+
+            var functionResult = input._content();
+            convert(functionResult, indent + origIndent);
+
+            outputTagObj.closeTag = true;
             outputTag(outputTagObj);
           }
         };


### PR DESCRIPTION
Hi,

With the current version of toXML, if we render an object that has a function, the values returned by the function are always treated as a string. For example, if we do:

    var person = {
        pets: function () {
            return [{ dog: "Rex" }, { cat: "Greebo" }];
        }
    }

    var xml = toXML(person);

The value of `xml` will be:

    <pets>[object Object],[object Object]</pets>

The change proposed above, the results of functions are fed again into the convert cycle, so the results of a function are treated as their own types. The output of the call to `toXML`, with the same input as above, would be:

    <pets><dog>Rex</dog><cat>Greebo</cat></pets>