### PR TITLE
build(deps-dev): bump github actions

### DIFF
--- a/.github/workflows/ unit-tests.yml
+++ b/.github/workflows/ unit-tests.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       # Checks out code from Github.
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Restore cache if available.
       - name: Restore cached dependencies
         id: dep-cache

--- a/.github/workflows/ unit-tests.yml
+++ b/.github/workflows/ unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
       # Restore cache if available.
       - name: Restore cached dependencies
         id: dep-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: jstoxml-cache
         with:


### PR DESCRIPTION
Bump GitHub Actions to their latest major versions. Main change is they're now using Node 16 instead of 12.