### PR TITLE
refactor(jstoxml): remove superfluous arg

### DIFF
--- a/jstoxml.js
+++ b/jstoxml.js
@@ -333,7 +333,7 @@ export const toXML = (obj = {}, config = {}) => {
                 // Fallthrough: just pass the key as the content for the new special-object.
                 if (typeof outputObj._content === 'undefined') outputObj._content = obj[key];
 
-                const xml = toXML(outputObj, newConfig, key);
+                const xml = toXML(outputObj, newConfig);
 
                 return xml;
             }, config);


### PR DESCRIPTION
This PR just removes a superfluous argument that is passed to the `toXML()` function, which only expects two arguments:

https://github.com/davidcalhoun/jstoxml/blob/0bbd491de8bdf944c78db4119a5e9ce3cb3f57f4/jstoxml.js#L175