### PR TITLE
Add newlines with empty indent

### DIFF
--- a/jstoxml.js
+++ b/jstoxml.js
@@ -203,6 +203,8 @@ export const toXML = (obj = {}, config = {}) => {
         ? {}
         : { ...defaultEntityReplacements, ...rawContentReplacements };
 
+    const shouldAddNewlines = typeof indent === 'string';
+
     // Determines indent based on depth.
     const indentStr = getIndentStr(indent, depth);
 
@@ -213,7 +215,7 @@ export const toXML = (obj = {}, config = {}) => {
 
     const isOutputStart = _isOutputStart && !headerStr && _isFirstItem && depth === 0;
 
-    const preIndentStr = indent && !isOutputStart ? '\n' : '';
+    const preIndentStr = shouldAddNewlines && !isOutputStart ? '\n' : '';
 
     let outputStr = '';
     switch (valType) {
@@ -284,7 +286,7 @@ export const toXML = (obj = {}, config = {}) => {
             const tag = `<${_name}${attributesString}${selfCloseStr}>`;
 
             // Post-tag output (closing tag, indent, line breaks).
-            const preTagCloseStr = indent && !isNewValSimple && !isNewValCDATA ? `\n${indentStr}` : '';
+            const preTagCloseStr = shouldAddNewlines && !isNewValSimple && !isNewValCDATA ? `\n${indentStr}` : '';
             const postTag = !shouldSelfClose ? `${newVal}${preTagCloseStr}</${_name}>` : '';
             outputStr += `${preTag}${tag}${postTag}`;
             break;

--- a/test.js
+++ b/test.js
@@ -260,6 +260,22 @@ describe('toXML', () => {
             assert.equal(result, expectedResult);
         });
 
+        it('nesting with empty indent', () => {
+            const val = {
+                foo: {
+                    foo: 'bar',
+                    foo2: 'bar2'
+                }
+            };
+            const config = { indent: '' };
+            const result = toXML(val, config);
+            const expectedResult = `<foo>
+<foo>bar</foo>
+<foo2>bar2</foo2>
+</foo>`;
+            assert.equal(result, expectedResult);
+        });
+
         it('deep nesting', () => {
             const val = {
                 a: {


### PR DESCRIPTION
Closes https://github.com/davidcalhoun/jstoxml/issues/76

This patch enables adding newlines to the output by passing an empty string as indent